### PR TITLE
Now using utf8 to decode requests

### DIFF
--- a/communio/lib/model/person_found.dart
+++ b/communio/lib/model/person_found.dart
@@ -11,7 +11,7 @@ class PersonFound {
 
   static Future<PersonFound> fromNetwork (String url) async{
     final response = await http.get(url);
-    final responseJson = json.decode(response.body);
+    final responseJson = json.decode(utf8.decode(response.bodyBytes));
     return PersonFound(
       name: responseJson['name'],
       photo: responseJson['photo'],

--- a/communio/lib/redux/action_creators.dart
+++ b/communio/lib/redux/action_creators.dart
@@ -52,7 +52,7 @@ ThunkAction<AppState> queryFriendsList() {
     final Set<Friend> friends = new Set<Friend>();
     final response = await http.get(friendQueryUrl);
     if (response.statusCode == 200) {
-      final Iterable friendsJson = json.decode(response.body);
+      final Iterable friendsJson = json.decode(utf8.decode(response.bodyBytes));
       friendsJson.forEach((friendJson) {
         final Friend friend = Friend.fromJson(friendJson);
         friends.add(friend);


### PR DESCRIPTION
All requests are now decoded using utf8 in order to get special characters. This was initially thought to be due to the font, which proved to not be true, since logs displayed the values as displayed.